### PR TITLE
Resolve no fonts in Java AWT

### DIFF
--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -27,7 +27,7 @@ LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apk add --update --no-cache ca-certificates curl fontconfig git openssl sqlite tar tzdata \
+RUN         apk add --update --no-cache ca-certificates curl fontconfig git openssl sqlite tar tzdata terminus-font \
 			    && adduser -D -h /home/container container
 
 USER        container


### PR DESCRIPTION
```java.lang.InternalError: java.lang.reflect.InvocationTargetException
	at sun.font.FontManagerFactory$1.run(Unknown Source) ~[?:?]
	at java.security.AccessController.doPrivileged(Unknown Source) ~[?:?]
	at sun.font.FontManagerFactory.getInstance(Unknown Source) ~[?:?]
	at java.awt.Font.<init>(Unknown Source) ~[?:?]
	at java.awt.Font.createFont(Unknown Source) ~[?:?]
	at com.arceon.core.command.TextHandler.<init>(TextHandler.java:56) ~[?:?]
	at com.arceon.core.ArceonCommandManager.initialize(ArceonCommandManager.java:47) ~[?:?]
	at com.arceon.core.ArceonCommandManager.<init>(ArceonCommandManager.java:34) ~[?:?]
	at com.arceon.core.Main.onEnable(Main.java:49) ~[?:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:263) ~[patched_1.17.1.jar:git-Paper-112]
	at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:370) ~[patched_1.17.1.jar:git-Paper-112]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:500) ~[patched_1.17.1.jar:git-Paper-112]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.enablePlugin(CraftServer.java:518) ~[patched_1.17.1.jar:git-Paper-112]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.enablePlugins(CraftServer.java:432) ~[patched_1.17.1.jar:git-Paper-112]
	at net.minecraft.server.MinecraftServer.loadWorld(MinecraftServer.java:639) ~[patched_1.17.1.jar:git-Paper-112]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:306) ~[patched_1.17.1.jar:git-Paper-112]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1126) ~[patched_1.17.1.jar:git-Paper-112]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[patched_1.17.1.jar:git-Paper-112]
	at java.lang.Thread.run(Unknown Source) [?:?]
Caused by: java.lang.reflect.InvocationTargetException
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source) ~[?:?]
	at java.lang.reflect.Constructor.newInstanceWithCaller(Unknown Source) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Unknown Source) ~[?:?]
	... 19 more
Caused by: java.lang.NullPointerException: Cannot load from short array because "sun.awt.FontConfiguration.head" is null
	at sun.awt.FontConfiguration.getVersion(Unknown Source) ~[?:?]
	at sun.awt.FontConfiguration.readFontConfigFile(Unknown Source) ~[?:?]
	at sun.awt.FontConfiguration.init(Unknown Source) ~[?:?]
	at sun.awt.X11FontManager.createFontConfiguration(Unknown Source) ~[?:?]
	at sun.font.SunFontManager$2.run(Unknown Source) ~[?:?]
	at sun.font.SunFontManager$2.run(Unknown Source) ~[?:?]
	at java.security.AccessController.doPrivileged(Unknown Source) ~[?:?]
	at sun.font.SunFontManager.<init>(Unknown Source) ~[?:?]
	at sun.awt.FcFontManager.<init>(Unknown Source) ~[?:?]
	at sun.awt.X11FontManager.<init>(Unknown Source) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source) ~[?:?]
	at java.lang.reflect.Constructor.newInstanceWithCaller(Unknown Source) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Unknown Source) ~[?:?]
	... 19 more
```